### PR TITLE
Handle status page query errors

### DIFF
--- a/statuspage.go
+++ b/statuspage.go
@@ -70,6 +70,13 @@ func (s *StatusPage) handle(w http.ResponseWriter, r *AuthenticatedRequest) {
 	rows, err := s.db.Query("SELECT ts, type, username FROM events WHERE ts >= NOW() - INTERVAL 1 WEEK ORDER BY ts DESC LIMIT 1000")
 	if err != nil {
 		log.Print("Error querying database: ", err)
+		http.Error(w, "Unable to load recent events", http.StatusInternalServerError)
+		return
+	}
+	if rows == nil {
+		log.Print("Database returned no rows result")
+		http.Error(w, "Unable to load recent events", http.StatusInternalServerError)
+		return
 	}
 	defer rows.Close()
 	for rows.Next() {


### PR DESCRIPTION
## Summary
- return an HTTP 500 response when the status page query fails and stop further processing
- guard the query result before closing rows to avoid nil dereferences

## Testing
- go test ./... *(fails: go tool reports go.mod needs tidying)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3165fe9883209d75fe73993af324