### PR TITLE
Return after rejecting non-GET status requests

### DIFF
--- a/statuspage.go
+++ b/statuspage.go
@@ -59,6 +59,7 @@ func (s *StatusPage) handle(w http.ResponseWriter, r *AuthenticatedRequest) {
 	// Only GET requests allowed
 	if r.Request.Method != "GET" {
 		http.Error(w, "405 Method not allowed", http.StatusMethodNotAllowed)
+		return
 	}
 
 	statusPageData := &StatusPageData{Username: r.Username}


### PR DESCRIPTION
## Summary
- return immediately when the status handler receives a non-GET request so no further processing occurs

## Testing
- `GOTOOLCHAIN=local go test ./...` *(fails: requires module downloads blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf312e64588320aa6006cdfebaa3e8