### PR TITLE
Handle GET requests for door control

### DIFF
--- a/doorcontrol.go
+++ b/doorcontrol.go
@@ -100,6 +100,11 @@ func createDoorControl(db *sql.DB, config *Configuration) *DoorControl {
 }
 
 func (d *DoorControl) handle(w http.ResponseWriter, r *AuthenticatedRequest) {
+	if r.Request.Method == "GET" {
+		http.Redirect(w, &r.Request, "/", http.StatusFound)
+		return
+	}
+
 	// Only POST requests allowed
 	if r.Request.Method != "POST" {
 		http.Error(w, "405 Method not allowed", http.StatusMethodNotAllowed)


### PR DESCRIPTION
## Summary
- redirect GET requests for the door control handler back to the home page
- keep POST activations and 405 handling for unsupported methods

## Testing
- go test ./... *(hangs in container; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68cf32ee7da08320a806b2f03a704008