### PR TITLE
Send closure alert after open-door notification

### DIFF
--- a/notifier.go
+++ b/notifier.go
@@ -14,10 +14,29 @@ const (
 	NOTIFICATION_CHECK_PERIOD = time.Duration(1) * time.Second
 )
 
+func sendNotificationEmail(config *Configuration, status string) {
+	to := strings.Join(config.Notifications.Emails, ",")
+	msg := "To: " + to + "\r\n" +
+		"Subject: " + status + "\r\n" +
+		"\r\n" +
+		status
+
+	log.Print("Sending email: ", msg)
+
+	auth := smtp.PlainAuth("",
+		config.Notifications.From, config.Notifications.Password, config.Notifications.Server)
+	err := smtp.SendMail(config.Notifications.Server+":"+strconv.Itoa(config.Notifications.Port), auth,
+		config.Notifications.From, config.Notifications.Emails, []byte(msg))
+
+	if err != nil {
+		log.Printf("smtp error: %v", err)
+	}
+}
+
 func notifier(config *Configuration, statusUpdates StatusUpdateChan) {
 	statusChange := time.Now()
 	lastStatus := STARTUP
-	notificationSent := false
+	openAlertSent := false
 
 	timeout := time.Duration(config.Notifications.TimeoutMillis) * time.Millisecond
 
@@ -25,33 +44,21 @@ func notifier(config *Configuration, statusUpdates StatusUpdateChan) {
 	for {
 		select {
 		case <-ticker.C:
-			if !notificationSent && lastStatus == NOTIFICATION_STATUS && time.Since(statusChange) > timeout {
-				notificationSent = true
-
-				to := strings.Join(config.Notifications.Emails, ",")
+			if !openAlertSent && lastStatus == NOTIFICATION_STATUS && time.Since(statusChange) > timeout {
 				status := fmt.Sprintf("Door has been %v for %v", lastStatus.String(), timeout)
-
-				msg := "To: " + to + "\r\n" +
-					"Subject: " + status + "\r\n" +
-					"\r\n" +
-					status
-
-				log.Print("Sending email: ", msg)
-
-				auth := smtp.PlainAuth("",
-					config.Notifications.From, config.Notifications.Password, config.Notifications.Server)
-				err := smtp.SendMail(config.Notifications.Server+":"+strconv.Itoa(config.Notifications.Port), auth,
-					config.Notifications.From, config.Notifications.Emails, []byte(msg))
-
-				if err != nil {
-					log.Printf("smtp error: %v", err)
-				}
+				sendNotificationEmail(config, status)
+				openAlertSent = true
 			}
 		case update := <-statusUpdates:
 			log.Print("Notifier got update:", update)
+			if update == CLOSED && openAlertSent {
+				sendNotificationEmail(config, "Door has closed")
+			}
+			if update != NOTIFICATION_STATUS {
+				openAlertSent = false
+			}
 			lastStatus = update
 			statusChange = time.Now()
-			notificationSent = false
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- add a helper to centralize notification email sending
- trigger a follow-up email when the door closes after a prolonged-open alert

## Testing
- timeout 10 go test ./... *(fails: times out waiting on hardware-dependent tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f7de65ac8320bf5113b0d791c91e